### PR TITLE
Added in the Equalize Digital Accessibility Checker plugin as a suggested plugin.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -514,7 +514,14 @@ function crosswinds_framework_get_suggested_plugins() {
 			'slug'     => 'block-visibility',
 			'logo'     => 'https://ps.w.org/block-visibility/assets/icon-256x256.png',
 			'link'     => 'https://wordpress.org/plugins/block-visibility/',
-			'location' => 'external'
+			'location' => 'internal'
+		),
+		array(
+			'name'     => 'Equalize Digital Accessibility Checker',
+			'slug'     => 'accessibility-checker',
+			'logo'     => 'https://ps.w.org/accessibility-checker/assets/icon-256x256.png',
+			'link'     => 'https://wordpress.org/plugins/accessibility-checker/',
+			'location' => 'internal'
 		)
 	);
 


### PR DESCRIPTION
## Describe the pull request. 
This adds the Equalize Digital Accessibility Checker plugin as a suggested plugin when using the Crosswinds Framework theme or one of the child themes.

## Why should this pull request be accepted?  
We should always be promoting accessibility, and this is one of the best a11y plugins that can be used.

## Related issue
#39 

## Checklist
- [x] You've tested this issue with the latest version of the plugin.
- [x] There are no other pull requests related to this issue.
- [x] You've added all of the proper documentation in the code.