### PR TITLE
Fixed how photo grid photos look in the editor.

### DIFF
--- a/assets/css/src/editor/_editor-defaults.css
+++ b/assets/css/src/editor/_editor-defaults.css
@@ -31,9 +31,10 @@ img {
 	display: flex;
 }
 
-.photo-grid{
+.photo-grid {
 
-	& .wp-block-image {
+	& .wp-block-image,
+	& .wp-block-post-featured-image {
 		width: 100%;
 		height: 100%;
 		overflow: hidden;
@@ -48,6 +49,9 @@ img {
 		& .components-resizable-box__container {
 			min-height: 0 !important;
 			min-width: 0 !important;
+			max-width: none !important;
+			max-height: none !important;
+			height: 100% !important;
 		}
 
 		& img {


### PR DESCRIPTION
## Describe the pull request
Fixes the issue with photo grid photos not looking correct in the editor.

## Why should this pull request be accepted?
It fixes an issue that could be annoying to users.

## How does this pull request work?
Makes the photo grid photos look the same in the editor as they do on the front end.

## Instructions for testing
1. Create a new page.
2. Add a basic grid block.
3. Add basic grid items with photos of different sizes.
4. All photos should have the same height.

## Related issue
#42 

## Checklist
- [x] You've tested this issue with the latest version of the plugin.
- [x] There are no other pull requests related to this issue.
- [x] You've added all of the proper documentation in the code.